### PR TITLE
Add terminal colors

### DIFF
--- a/cdi.sh
+++ b/cdi.sh
@@ -3,6 +3,70 @@
 # CDI - Change Dir Interactively
 # Don't waste more time in the terminal browsing folders with CD
 
+# helper function to colorize terminal text
+color_print() {
+    # function call syntax
+    # print_color "text to print" <foreground-color> <formatting> <background-color>
+
+    # Foreground colors
+    get_foreground() {
+        case $1 in 
+            'black') printf "\033[30m" ;;
+            'red') printf "\033[31m" ;;
+            'green') printf "\033[32m" ;;
+            'orange') printf "\033[33m" ;;
+            'blue') printf "\033[34m" ;;
+            'magenta') printf "\033[35m" ;;
+            'cyan') printf "\033[36m" ;;
+            'gray') printf "\033[37m" ;;
+            *) printf "\033[39m" ;; # default or anything else
+        esac
+    }
+
+    # Formatting
+    get_formatting() {
+        case $1 in
+            'bold') printf '\033[1m' ;;
+            'underline') printf '\033[4m' ;;
+            'bold-underline') printf '\033[4m\033[1m' ;;
+            *) printf '\033[22m\033[24m' ;; # code 22 to disable bold, 24 for underline
+        esac
+    }
+
+    # Background colors
+    get_background() {
+        case $1 in
+            'black') printf '\033[40m' ;;
+            'red') printf '\033[41m' ;;
+            'green') printf '\033[42m' ;;
+            'orange') printf '\033[43m' ;;
+            'blue') printf '\033[44m' ;;
+            'magenta') printf '\033[45m' ;;
+            'cyan') printf '\033[46m' ;;
+            'light-gray') printf '\033[47m' ;;
+            'gray') printf '\033[100m' ;;
+            'light-red') printf '\033[101m' ;;
+            'light-green') printf '\033[102m' ;;
+            'yellow') printf '\033[103m' ;;
+            'light-blue') printf '\033[104m' ;;
+            'light-purple') printf '\033[105m' ;;
+            'teal') printf '\033[106m' ;;
+            'white') printf '\033[107m' ;;
+            *) printf '\033[49m' ;; # default or anything else
+        esac
+    }
+
+    FORE=`get_foreground $2`
+    BACK=`get_background $4`
+    FMT=`get_formatting $3`
+
+    printf "$FORE$BACK$FMT$1\n"
+    # reset all formatting, can be combined to a single line for reduced code
+    printf '\033[39m' # default foreground
+    printf '\033[49m' # default background
+    printf '\033[22m\033[24m' # default formatting
+}
+
 print_folders() {
     # $1 = current_dir
     # $2 = current_selection
@@ -14,18 +78,23 @@ print_folders() {
     if [ "${#array[@]}" -ne 0 ]; then
         for i in "${!array[@]}"; do
             if test "$i" -eq $2; then
-                echo -e "\033[1m→ ${array[i]}\033[0m"
+                # echo -e "\033[1m→ ${array[i]}\033[0m"
+                printf "→ " # print selection arrow on same line
+                color_print "${array[i]}" green bold-underline
             else
-                echo "  ${array[i]}"
+                # echo "  ${array[i]}"
+                color_print "  ${array[i]}" 
             fi
         done
     else
-        echo -e 'No folders here, press \033[1m←\033[0m to back'
+        #echo -e 'No folders here, press \033[1m←\033[0m to back'
+        color_print 'No folders here, press ← to back' red
     fi
 }
 
 print_status() {
-    echo -e "[ \033[1m$1\033[0m ]\n"
+    #echo -e "[ \033[1m$1\033[0m ]\n"
+    color_print " [ $1 ]\n" orange bold
     #echo -e "Selection $2 \n"
 }
 


### PR DESCRIPTION
Hey @antonioolf ,

I have included the function to print colored lines as discussed in #8 .
As requested, i have removed the underline style from the arrow head. This is the syntax to call the function:

```sh
color_print "text to print here" <foreground-color> <formatting> <background-color>
```

`<foreground-color>` can take any of these colors: red, green, orange, blue, magenta, cyan, grey, black  
`<formatting>` can take one of these: bold, underline, bold-underline(to have both)  
`<background-color>` can take: black, red, green, orange, magenta, blue, cyan, gray, yellow, light-gray, light-green, light-red, light-blue, light-purple, teal, white

If provided anything else other than the above mentioned parameters, it sets the color/formatting back to the console defaults

I have currently commented the older `echo` statements instead of removing them as you may need them in future.  
I find this project interesting, so please let me know if can take up any other issues! Thanks!