### PR TITLE
Bugfix on folder spaces

### DIFF
--- a/cdi.sh
+++ b/cdi.sh
@@ -3,6 +3,10 @@
 # CDI - Change Dir Interactively
 # Don't waste more time in the terminal browsing folders with CD
 
+# change field separator to new-line to easily handle spaces in folder names.
+# To revert back to default space seperator, use `unset IFS` where required
+IFS=$'\n'
+
 # helper function to colorize terminal text
 color_print() {
     # function call syntax


### PR DESCRIPTION
This PR can close #2 , #6 . I was able to come up with a simple fix for this. I just changed the Input Field Separator (IFS) variable to make bash break at new-line instead of the default space separator. I figured out this would be the easiest fix as the program (`cdi.sh`) is based on splitting at new-lines (w.r.t `ls`). In future, in case you need to revert back to default in some function, you can always use `unset IFS` to remove the modifications.

This is how it was before:
![1](https://user-images.githubusercontent.com/42943423/95009378-45e0d180-063f-11eb-969e-7f47f1eca926.png)

Here's how it looks now:
![2](https://user-images.githubusercontent.com/42943423/95009381-49745880-063f-11eb-8507-e5ed78579017.png)

When you `cd` into `folder with spaces`, it looks like:
![3](https://user-images.githubusercontent.com/42943423/95009396-627d0980-063f-11eb-8439-058b687c4607.png)

You can check the changes in code (it's just one line) in the files changed tab in the PR and let me know if I should make any more changes. Thank You!